### PR TITLE
Improve newsletter issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/newsletter_ready.md
+++ b/.github/ISSUE_TEMPLATE/newsletter_ready.md
@@ -1,0 +1,28 @@
+---
+name: "Newsletter Ready"
+about: "Auto-generated developer tools newsletter"
+title: "Newsletter Ready"
+labels: [newsletter, automation, ready-to-send]
+---
+
+# 📧 Developer Tools Newsletter
+
+> **Hey GitHub visitors!** This is a **FREE preview** of our developer tools newsletter. Want the **full experience** with exclusive founder interviews, live demos, and early access to trending tools? [**Subscribe here for free!**](YOUR_NEWSLETTER_LINK)
+
+---
+
+{{newsletter_content}}
+
+---
+
+### Next Steps (For Newsletter Owner)
+1. **Copy** the content above
+2. **Paste** into your newsletter editor (Substack, ConvertKit, etc.)
+3. **Send** to your subscribers!
+
+---
+
+*File Location: {{file}}*
+*This issue was automatically created by our newsletter automation system.*
+
+**Like what you see? Star this repo and follow for daily updates!**

--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -112,50 +112,13 @@ jobs:
             const currentDate = new Date().toISOString().slice(0, 10);
             const issueTitle = 'Newsletter Ready - ' + currentDate;
             
-            const issueBodyParts = [
-              '## Your Developer Tools Newsletter is Ready!',
-              '',
-              '> **Hey GitHub visitors!** This is a **FREE preview** of our developer tools newsletter. Want the **full experience** with exclusive founder interviews, live demos, and early access to trending tools?',
-              '[**Subscribe here for free!**](YOUR_NEWSLETTER_LINK)',
-              '',
-              '**Copy-paste ready content below:**',
-              '',
-              '---',
-              '',
-              newsletterContent,
-              '',
-              '---',
-              '',
-              '## Next Steps (For Newsletter Owner):',
-              '',
-              '1. **Copy** the content above',
-              '2. **Paste** into your newsletter editor (Substack, ConvertKit, etc.)',
-              '3. **Send** to your subscribers!',
-              '',
-              '---',
-              '',
-              '## Want More Premium Content Like This?',
-              '',
-              '### **Subscribe to Our Newsletter for Exclusive Access:**',
-              '- **Founder Interviews**',
-              '- **Live Product Demos**',
-              '- **Monthly Webinars**',
-              '- **Early Access**',
-              '- **Deep Analysis**',
-              '- **Community**',
-              '',
-              '**[Subscribe Free - No Spam, Just Value](YOUR_NEWSLETTER_LINK)**',
-              '',
-              '---',
-              '',
-              '### File Location: ' + latestFile,
-              '*This issue was automatically created by our newsletter automation system*',
-              '',
-              '**Like what you see? Star this repo and follow for daily updates!**'
-            ];
             
-            const issueBody = issueBodyParts.join('\n');
-            
+            const templatePath = path.join('.github', 'ISSUE_TEMPLATE', 'newsletter_ready.md');
+            let issueBody = fs.readFileSync(templatePath, 'utf8');
+
+            issueBody = issueBody
+              .replace('{{newsletter_content}}', newsletterContent)
+              .replace('{{file}}', latestFile);
             console.log('Creating GitHub issue...');
             
             const response = await github.rest.issues.create({


### PR DESCRIPTION
## Summary
- add a rich `newsletter_ready.md` template under `.github/ISSUE_TEMPLATE`
- use the template in the newsletter workflow so new issues match newsletter style

## Testing
- `python3 automation/simple_automation.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_686d215626008322bafc0027c53784af